### PR TITLE
[RTD-708] Added simple splitter by using spring integration

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/AppConfiguration.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/AppConfiguration.java
@@ -1,5 +1,6 @@
 package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument;
 
+import com.mongodb.MongoException;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.repositories.EnrolledPaymentInstrumentRepository;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.services.InstrumentRevokeNotificationService;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.KafkaRevokeNotificationService;
@@ -8,7 +9,19 @@ import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.persistence
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.dao.RecoverableDataAccessException;
+import org.springframework.dao.TransientDataAccessException;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+import javax.validation.ConstraintViolationException;
+import java.io.IOException;
+import java.net.ConnectException;
+import java.net.SocketTimeoutException;
+import java.net.UnknownHostException;
+import java.util.Set;
+import java.util.UnknownFormatConversionException;
 
 @Configuration
 @EnableMongoRepositories(basePackages = "it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.persistence.repositories")
@@ -26,6 +39,38 @@ public class AppConfiguration {
   @Bean
   public InstrumentRevokeNotificationService revokeService(StreamBridge bridge) {
     return new KafkaRevokeNotificationService(PRODUCER_BINDING, bridge);
+  }
+
+  /**
+   * A list of exceptions considered as "transient", so these are used as
+   * retryable exceptions with kafka consumers.
+   */
+  @Bean("retryableExceptions")
+  Set<Class<? extends Exception>> consumerRetryableExceptions() {
+    return Set.of(
+            SocketTimeoutException.class,
+            ConnectException.class,
+            UnknownHostException.class,
+            IOException.class,
+            MongoException.class,
+            RecoverableDataAccessException.class,
+            TransientDataAccessException.class,
+            DuplicateKeyException.class,
+            OptimisticLockingFailureException.class
+    );
+  }
+
+  /**
+   * A list of non-transient exceptions. Tipically validation and schema error
+   * where no recovery operation are available.
+   */
+  @Bean("fatalExceptions")
+  Set<Class<? extends Exception>> consumerFatalExceptions() {
+    return Set.of(
+            IllegalArgumentException.class,
+            ConstraintViolationException.class,
+            UnknownFormatConversionException.class
+    );
   }
 
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/KafkaConfiguration.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/KafkaConfiguration.java
@@ -38,6 +38,8 @@ import java.util.function.Consumer;
 @Slf4j
 public class KafkaConfiguration {
 
+  private static final Long FIXED_BACKOFF_INTERVAL = 3000L;
+
   @Bean
   MessageRoutingCallback kafkaRouter(@Autowired ObjectMapper objectMapper) {
     return new PaymentInstrumentEventRouter(
@@ -61,35 +63,6 @@ public class KafkaConfiguration {
   }
 
   @Bean
-  Consumer<TokenManagerWalletChanged> tkmWalletEventConsumer() {
-    return message -> log.info("TKM event: {}", message);
-  }
-
-  @Bean("retryableExceptions")
-  Set<Class<? extends Exception>> kafkaRetryableExceptions() {
-    return Set.of(
-            SocketTimeoutException.class,
-            ConnectException.class,
-            UnknownHostException.class,
-            IOException.class,
-            MongoException.class,
-            RecoverableDataAccessException.class,
-            TransientDataAccessException.class,
-            DuplicateKeyException.class,
-            OptimisticLockingFailureException.class
-    );
-  }
-
-  @Bean("fatalExceptions")
-  Set<Class<? extends Exception>> kafkaFatalExceptions() {
-    return Set.of(
-            IllegalArgumentException.class,
-            ConstraintViolationException.class,
-            UnknownFormatConversionException.class
-    );
-  }
-
-  @Bean
   ListenerContainerCustomizer<AbstractMessageListenerContainer<?, ?>> listenerCustomization(
           DefaultErrorHandler errorHandler
   ) {
@@ -109,10 +82,8 @@ public class KafkaConfiguration {
     // like db connection error or write error. While allow to set
     // not retryable exceptions like validation error which cannot be recovered with a retry.
     final var errorHandler = new DefaultErrorHandler(
-            new FixedBackOff(3000L, FixedBackOff.UNLIMITED_ATTEMPTS)
+            new FixedBackOff(FIXED_BACKOFF_INTERVAL, FixedBackOff.UNLIMITED_ATTEMPTS)
     );
-    //errorHandler.setAckAfterHandle(false);
-    //errorHandler.setCommitRecovered(false);
     retryableExceptions.forEach(errorHandler::addRetryableExceptions);
     fatalExceptions.forEach(errorHandler::addNotRetryableExceptions);
     return errorHandler;

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/SplitterConfiguration.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/SplitterConfiguration.java
@@ -1,0 +1,89 @@
+package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument;
+
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.splitter.TokenManagerWalletEventSplitter;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerCardChanged;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerWalletChanged;
+import org.springframework.classify.BinaryExceptionClassifier;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.dsl.*;
+import org.springframework.integration.handler.LoggingHandler;
+import org.springframework.integration.handler.advice.RequestHandlerRetryAdvice;
+import org.springframework.integration.handler.advice.RetryStateGenerator;
+import org.springframework.integration.handler.advice.SpelExpressionRetryStateGenerator;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.retry.support.RetryTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+@Configuration
+public class SplitterConfiguration {
+
+  private static final String TO_SPLIT_BINDING = "tkmWalletEventConsumer-in-0";
+  private static final String TARGET_OUT_BINDING = "rtdEnrolledPimProducer-out-0";
+  private static final Long FIXED_BACKOFF_INTERVAL = 3000L;
+
+  @Bean
+  Function<TokenManagerWalletChanged, List<TokenManagerCardChanged>> splitter() {
+    return new TokenManagerWalletEventSplitter();
+  }
+
+  @Bean
+  public IntegrationFlow splitterFlow(StreamBridge bridge, RequestHandlerRetryAdvice retryAdvice) {
+    return IntegrationFlows.from(TO_SPLIT_BINDING, true)
+            .log(LoggingHandler.Level.INFO, m -> "Received message to split: " + m.getHeaders())
+            .split(TokenManagerWalletChanged.class, splitter())
+            .log(LoggingHandler.Level.INFO, m -> "Split message " + m.getPayload())
+            .handle(TokenManagerCardChanged.class,
+                    (payload, headers) -> {
+                      bridge.send(TARGET_OUT_BINDING, MessageBuilder.withPayload(payload)
+                              .setHeader("partitionKey", payload.getHashPan())
+                              .build()
+                      );
+                      return null;
+                    },
+                    e -> e.advice(retryAdvice)
+            ).get();
+  }
+
+  /**
+   * Retry configuration for splitter integration flow. It defines an infinite retry policy
+   * with 3 seconds as backoff policy. Also allow to retry the message processing only when a
+   * retryable exceptions happens.
+   * Official doc: <a href="https://docs.spring.io/spring-integration/reference/html/messaging-endpoints.html#retry-advice">...</a>
+   *
+   * @param stateGenerator      The state generator to enable statefull retry.
+   * @param retryableExceptions A Set of retryable exceptions
+   */
+  @Bean
+  RequestHandlerRetryAdvice retryAdvice(
+          RetryStateGenerator stateGenerator,
+          Set<Class<? extends Throwable>> retryableExceptions
+  ) {
+    final var retryAdvice = new RequestHandlerRetryAdvice();
+    final var retryTemplate = RetryTemplate.builder()
+            .infiniteRetry()
+            .traversingCauses()
+            .retryOn(new ArrayList<>(retryableExceptions))
+            .fixedBackoff(FIXED_BACKOFF_INTERVAL)
+            .build();
+    retryAdvice.setRetryStateGenerator(stateGenerator);
+    retryAdvice.setRetryTemplate(retryTemplate);
+    return retryAdvice;
+  }
+
+  @Bean
+  RetryStateGenerator splitFlowRetryStateGenerator(
+          Set<Class<? extends Throwable>> retryableExceptions
+  ) {
+    final var stateGenerator = new SpelExpressionRetryStateGenerator(
+            "headers['correlationId']"
+    );
+    stateGenerator.setClassifier(new BinaryExceptionClassifier(retryableExceptions, true));
+    return stateGenerator;
+  }
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/SplitterConfiguration.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/SplitterConfiguration.java
@@ -1,53 +1,77 @@
 package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument;
 
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.IntegrationFlowKafkaProperties;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.splitter.TokenManagerCardEventPublisher;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.splitter.TokenManagerWalletEventSplitter;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerCardChanged;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerWalletChanged;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.classify.BinaryExceptionClassifier;
 import org.springframework.cloud.stream.function.StreamBridge;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.integration.dsl.*;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.handler.LoggingHandler;
 import org.springframework.integration.handler.advice.RequestHandlerRetryAdvice;
 import org.springframework.integration.handler.advice.RetryStateGenerator;
 import org.springframework.integration.handler.advice.SpelExpressionRetryStateGenerator;
-import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.integration.kafka.dsl.Kafka;
+import org.springframework.integration.kafka.inbound.KafkaMessageDrivenChannelAdapter;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.retry.support.RetryTemplate;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 
 @Configuration
+@EnableConfigurationProperties
 public class SplitterConfiguration {
 
-  private static final String TO_SPLIT_BINDING = "tkmWalletEventConsumer-in-0";
   private static final String TARGET_OUT_BINDING = "rtdEnrolledPimProducer-out-0";
   private static final Long FIXED_BACKOFF_INTERVAL = 3000L;
 
   @Bean
-  Function<TokenManagerWalletChanged, List<TokenManagerCardChanged>> splitter() {
-    return new TokenManagerWalletEventSplitter();
+  public IntegrationFlow splitterFlow(
+          KafkaMessageDrivenChannelAdapter<String, TokenManagerWalletChanged> input,
+          StreamBridge bridge,
+          RequestHandlerRetryAdvice retryAdvice
+  ) {
+    return IntegrationFlows.from(input)
+            .log(LoggingHandler.Level.INFO, m -> "Received message to split: " + m.getHeaders())
+            .split(TokenManagerWalletChanged.class, splitter(), e -> e.advice(retryAdvice))
+            .log(LoggingHandler.Level.INFO, m -> "Split message " + m.getPayload())
+            .handle(
+                    TokenManagerCardChanged.class,
+                    TokenManagerCardEventPublisher.asHandler(TARGET_OUT_BINDING, bridge),
+                    e -> e.advice(retryAdvice)
+            )
+            .get();
+  }
+
+
+  @Bean
+  KafkaMessageDrivenChannelAdapter<String, TokenManagerWalletChanged> input(
+          DefaultErrorHandler errorHandler,
+          IntegrationFlowKafkaProperties flowKafkaProperties
+  ) {
+    final var consumerFactory = new DefaultKafkaConsumerFactory<String, TokenManagerWalletChanged>(new HashMap<>(flowKafkaProperties.tkmBulkConsumer));
+    final var containerProperties = new ContainerProperties(flowKafkaProperties.tkmBulkConsumer.get("topic"));
+    containerProperties.setAckMode(ContainerProperties.AckMode.RECORD);
+    final var container = new ConcurrentMessageListenerContainer<>(consumerFactory, containerProperties);
+    container.setCommonErrorHandler(errorHandler);
+    return Kafka.messageDrivenChannelAdapter(container, KafkaMessageDrivenChannelAdapter.ListenerMode.record).get();
   }
 
   @Bean
-  public IntegrationFlow splitterFlow(StreamBridge bridge, RequestHandlerRetryAdvice retryAdvice) {
-    return IntegrationFlows.from(TO_SPLIT_BINDING, true)
-            .log(LoggingHandler.Level.INFO, m -> "Received message to split: " + m.getHeaders())
-            .split(TokenManagerWalletChanged.class, splitter())
-            .log(LoggingHandler.Level.INFO, m -> "Split message " + m.getPayload())
-            .handle(TokenManagerCardChanged.class,
-                    (payload, headers) -> {
-                      bridge.send(TARGET_OUT_BINDING, MessageBuilder.withPayload(payload)
-                              .setHeader("partitionKey", payload.getHashPan())
-                              .build()
-                      );
-                      return null;
-                    },
-                    e -> e.advice(retryAdvice)
-            ).get();
+  Function<TokenManagerWalletChanged, List<TokenManagerCardChanged>> splitter() {
+    return new TokenManagerWalletEventSplitter();
   }
 
   /**
@@ -56,33 +80,34 @@ public class SplitterConfiguration {
    * retryable exceptions happens.
    * Official doc: <a href="https://docs.spring.io/spring-integration/reference/html/messaging-endpoints.html#retry-advice">...</a>
    *
-   * @param stateGenerator      The state generator to enable statefull retry.
-   * @param retryableExceptions A Set of retryable exceptions
+   * @param stateGenerator The state generator to enable statefull retry.
    */
   @Bean
   RequestHandlerRetryAdvice retryAdvice(
           RetryStateGenerator stateGenerator,
-          Set<Class<? extends Throwable>> retryableExceptions
+          RetryTemplate retryTemplate
   ) {
     final var retryAdvice = new RequestHandlerRetryAdvice();
-    final var retryTemplate = RetryTemplate.builder()
-            .infiniteRetry()
-            .traversingCauses()
-            .retryOn(new ArrayList<>(retryableExceptions))
-            .fixedBackoff(FIXED_BACKOFF_INTERVAL)
-            .build();
     retryAdvice.setRetryStateGenerator(stateGenerator);
     retryAdvice.setRetryTemplate(retryTemplate);
     return retryAdvice;
   }
 
   @Bean
+  RetryTemplate retryTemplate(Set<Class<? extends Throwable>> retryableExceptions) {
+    return RetryTemplate.builder()
+            .infiniteRetry()
+            .traversingCauses()
+            .retryOn(new ArrayList<>(retryableExceptions))
+            .fixedBackoff(FIXED_BACKOFF_INTERVAL)
+            .build();
+  }
+
+  @Bean
   RetryStateGenerator splitFlowRetryStateGenerator(
           Set<Class<? extends Throwable>> retryableExceptions
   ) {
-    final var stateGenerator = new SpelExpressionRetryStateGenerator(
-            "headers['correlationId']"
-    );
+    final var stateGenerator = new SpelExpressionRetryStateGenerator("headers['correlationId']");
     stateGenerator.setClassifier(new BinaryExceptionClassifier(retryableExceptions, true));
     return stateGenerator;
   }

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/configurations/AppConfiguration.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/configurations/AppConfiguration.java
@@ -1,4 +1,4 @@
-package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument;
+package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.configurations;
 
 import com.mongodb.MongoException;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.repositories.EnrolledPaymentInstrumentRepository;

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/configurations/KafkaConfiguration.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/configurations/KafkaConfiguration.java
@@ -1,4 +1,4 @@
-package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument;
+package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.configurations;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mongodb.MongoException;

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/configurations/SplitterConfiguration.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/configurations/SplitterConfiguration.java
@@ -1,6 +1,6 @@
-package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument;
+package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.configurations;
 
-import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.IntegrationFlowKafkaProperties;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.configurations.properties.IntegrationFlowKafkaProperties;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.splitter.TokenManagerCardEventPublisher;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.splitter.TokenManagerWalletEventSplitter;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerCardChanged;

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/configurations/properties/IntegrationFlowKafkaProperties.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/configurations/properties/IntegrationFlowKafkaProperties.java
@@ -1,4 +1,4 @@
-package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka;
+package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.configurations.properties;
 
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/IntegrationFlowKafkaProperties.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/IntegrationFlowKafkaProperties.java
@@ -1,0 +1,14 @@
+package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@ConfigurationProperties(prefix = "integration-flow")
+@Data
+public final class IntegrationFlowKafkaProperties {
+  public final Map<String, String> tkmBulkConsumer;
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/splitter/TokenManagerCardEventPublisher.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/splitter/TokenManagerCardEventPublisher.java
@@ -1,0 +1,34 @@
+package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.splitter;
+
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerCardChanged;
+import org.springframework.cloud.stream.function.StreamBridge;
+import org.springframework.integration.handler.GenericHandler;
+import org.springframework.messaging.support.MessageBuilder;
+
+public class TokenManagerCardEventPublisher {
+
+  public static GenericHandler<TokenManagerCardChanged> asHandler(
+          String outputBindingName,
+          StreamBridge bridge
+  ) {
+    final var publisher = new TokenManagerCardEventPublisher(outputBindingName, bridge);
+    return (payload, headers) -> {
+      publisher.sendTokenManagerCardChanged(payload);
+      return null;
+    };
+  }
+
+  private final String outputBindingName;
+  private final StreamBridge bridge;
+
+  public TokenManagerCardEventPublisher(String outputBindingName, StreamBridge bridge) {
+    this.outputBindingName = outputBindingName;
+    this.bridge = bridge;
+  }
+
+  public boolean sendTokenManagerCardChanged(TokenManagerCardChanged cardChanged) {
+    return bridge.send(outputBindingName, MessageBuilder.withPayload(cardChanged)
+            .setHeader("partitionKey", cardChanged.getHashPan()).build());
+  }
+
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/splitter/TokenManagerWalletEventSplitter.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/splitter/TokenManagerWalletEventSplitter.java
@@ -11,11 +11,10 @@ import java.util.stream.Collectors;
 
 public class TokenManagerWalletEventSplitter implements Function<TokenManagerWalletChanged, List<TokenManagerCardChanged>> {
 
-
-
   @Override
   public List<TokenManagerCardChanged> apply(TokenManagerWalletChanged tokenManagerWalletChanged) {
-    return tokenManagerWalletChanged.getCards()
+    return Optional.ofNullable(tokenManagerWalletChanged.getCards())
+            .orElse(Collections.emptyList())
             .stream()
             .map(it -> TokenManagerCardChanged.builder()
                     .hashPan(it.getHpan())

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/splitter/TokenManagerWalletEventSplitter.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/splitter/TokenManagerWalletEventSplitter.java
@@ -1,0 +1,38 @@
+package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.splitter;
+
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerCardChanged;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerWalletChanged;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class TokenManagerWalletEventSplitter implements Function<TokenManagerWalletChanged, List<TokenManagerCardChanged>> {
+
+
+
+  @Override
+  public List<TokenManagerCardChanged> apply(TokenManagerWalletChanged tokenManagerWalletChanged) {
+    return tokenManagerWalletChanged.getCards()
+            .stream()
+            .map(it -> TokenManagerCardChanged.builder()
+                    .hashPan(it.getHpan())
+                    .par(it.getPar())
+                    .changeType(it.getAction())
+                    .taxCode(tokenManagerWalletChanged.getTaxCode())
+                    .hashTokens(buildHashTokenEvents(it))
+                    .build()
+            )
+            .collect(Collectors.toList());
+  }
+
+  private List<TokenManagerCardChanged.HashTokenEvent> buildHashTokenEvents(TokenManagerWalletChanged.CardItem card) {
+    return Optional.ofNullable(card.getHtokens())
+            .orElse(Collections.emptyList())
+            .stream()
+            .map(token -> new TokenManagerCardChanged.HashTokenEvent(token.getHtoken(), token.getHaction()))
+            .collect(Collectors.toList());
+  }
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/ports/event/dto/TokenManagerCardChanged.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/ports/event/dto/TokenManagerCardChanged.java
@@ -31,9 +31,11 @@ public class TokenManagerCardChanged {
   private CardChangeType changeType;
 
   @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class HashTokenEvent {
-    final String hashToken;
-    final HashTokenChangeType changeType;
+    private String hashToken;
+    private HashTokenChangeType changeType;
   }
 
   public List<TkmUpdateCommand.TkmTokenCommand> toTkmTokenCommand() {

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/ports/event/dto/TokenManagerWalletChanged.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/ports/event/dto/TokenManagerWalletChanged.java
@@ -21,6 +21,7 @@ public final class TokenManagerWalletChanged {
   public static class CardItem {
     private final String hpan;
     private final String par;
+    private final CardChangeType action;
     private final List<HashTokenItem> htokens;
   }
 

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/ports/rest/KafkaRestControllerImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/ports/rest/KafkaRestControllerImpl.java
@@ -45,7 +45,7 @@ public class KafkaRestControllerImpl implements
     log.info("Sending tkm event {}", event);
     final var sent = streamBridge.send(
             TKM_BULK_CARD_BINDING,
-            MessageBuilder.withPayload(event).setHeader("partitionKey", 0).build()
+            MessageBuilder.withPayload(event).setHeader("partitionKey", "0").build()
     );
     log.info("Tkm event sent {}", sent);
   }

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/ports/rest/KafkaRestControllerImpl.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/ports/rest/KafkaRestControllerImpl.java
@@ -45,7 +45,7 @@ public class KafkaRestControllerImpl implements
     log.info("Sending tkm event {}", event);
     final var sent = streamBridge.send(
             TKM_BULK_CARD_BINDING,
-            MessageBuilder.withPayload(event).build()
+            MessageBuilder.withPayload(event).setHeader("partitionKey", 0).build()
     );
     log.info("Tkm event sent {}", sent);
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,9 +24,9 @@ integration-flow:
     value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
     allow.auto.create.topics: false
     max.poll.records: 1
-    sasl.jaas.config: ${KAFKA_SASL_JAAS_CONFIG_TKM_PIM}
-    sasl.mechanism: PLAIN
-    security.protocol: SASL_SSL
+#    sasl.jaas.config: ${KAFKA_SASL_JAAS_CONFIG_TKM_PIM}
+#    sasl.mechanism: PLAIN
+#    security.protocol: SASL_SSL
 
 spring:
   config:
@@ -78,11 +78,11 @@ spring:
             ackEachRecord: true
             ackMode: 'RECORD'
 
-      kafka:
-        binder:
-          configuration:
-            security.protocol: SASL_SSL
-            sasl.mechanism: PLAIN
+#      kafka:
+#        binder:
+#          configuration:
+#            security.protocol: SASL_SSL
+#            sasl.mechanism: PLAIN
 
       binders:
         kafka-enrolled-binder:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,7 @@ spring:
 
   cloud:
     function:
-      definition: functionRouter;tkmWalletEventConsumer
+      definition: functionRouter
     stream:
       function:
         routing:
@@ -28,6 +28,8 @@ spring:
           binder: kafka-enrolled-binder
           consumer:
             max-attempts: 1
+            ackEachRecord: true
+            ackMode: 'RECORD'
 
         tkmWalletEventConsumer-in-0:
           destination: ${KAFKA_TOPIC_TKM_BROKER:tkm-write-update-token}
@@ -36,6 +38,8 @@ spring:
           binder: kafka-tkm-binder
           consumer:
             max-attempts: 1
+            ackEachRecord: true
+            ackMode: 'RECORD'
 
         rtdEnrolledPimProducer-out-0:
           destination: ${KAFKA_TOPIC_EVENTS:rtd-enrolled-events}
@@ -44,17 +48,18 @@ spring:
           producer:
             partitionKeyExpression: ${KAFKA_PARTITION_KEY_EXPRESSION:headers.partitionKey}
             partitionCount: ${KAFKA_PARTITION_COUNT:1}
+            sync: true
 
         rtdRevokedPi-out-0:
           destination: ${KAFKA_TOPIC_REVOKE:rtd-revoke-pi}
           content-type: application/json
           binder: kafka-revoke-binder
 
-      kafka:
-        binder:
-          configuration:
-            security.protocol: SASL_SSL
-            sasl.mechanism: PLAIN
+#      kafka:
+#        binder:
+#          configuration:
+#            security.protocol: SASL_SSL
+#            sasl.mechanism: PLAIN
 
       binders:
         kafka-enrolled-binder:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,31 @@ logging:
     root: INFO
 
 
+## Topics and consumer groups
+topics:
+  enrolled-events:
+    topic: ${KAFKA_TOPIC_EVENTS:rtd-enrolled-events}
+    group: rtd-enrolled-payment-instrument-consumer-group
+  tkm-write-update:
+    topic: ${KAFKA_TOPIC_TKM_BROKER:tkm-write-update-token}
+    group: rtd-pim-consumer-group
+  revoke-pi:
+    topic: ${KAFKA_TOPIC_REVOKE:rtd-revoke-pi}
+
+# custom integration flow properties
+integration-flow:
+  tkmBulkConsumer:
+    topic: ${topics.tkm-write-update.topic}
+    bootstrap.servers: ${KAFKA_BROKER_TKM:localhost:29095}
+    group.id: ${topics.tkm-write-update.group}
+    key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    allow.auto.create.topics: false
+    max.poll.records: 1
+    sasl.jaas.config: ${KAFKA_SASL_JAAS_CONFIG_TKM_PIM}
+    sasl.mechanism: PLAIN
+    security.protocol: SASL_SSL
+
 spring:
   config:
     activate:
@@ -17,13 +42,11 @@ spring:
     function:
       definition: functionRouter
     stream:
-      function:
-        routing:
-          enabled: true
+      function.routing.enabled: true
       bindings:
         functionRouter-in-0:
-          destination: ${KAFKA_TOPIC_EVENTS:rtd-enrolled-events}
-          group: rtd-enrolled-payment-instrument-consumer-group
+          destination: ${topics.enrolled-events.topic}
+          group: ${topics.enrolled-events.group}
           content-type: application/json
           binder: kafka-enrolled-binder
           consumer:
@@ -31,18 +54,8 @@ spring:
             ackEachRecord: true
             ackMode: 'RECORD'
 
-        tkmWalletEventConsumer-in-0:
-          destination: ${KAFKA_TOPIC_TKM_BROKER:tkm-write-update-token}
-          group: rtd-pim-consumer-group
-          content-type: application/json
-          binder: kafka-tkm-binder
-          consumer:
-            max-attempts: 1
-            ackEachRecord: true
-            ackMode: 'RECORD'
-
         rtdEnrolledPimProducer-out-0:
-          destination: ${KAFKA_TOPIC_EVENTS:rtd-enrolled-events}
+          destination: ${topics.enrolled-events.topic}
           content-type: application/json
           binder: kafka-enrolled-binder
           producer:
@@ -51,15 +64,25 @@ spring:
             sync: true
 
         rtdRevokedPi-out-0:
-          destination: ${KAFKA_TOPIC_REVOKE:rtd-revoke-pi}
+          destination: ${topics.revoke-pi.topic}
           content-type: application/json
           binder: kafka-revoke-binder
 
-#      kafka:
-#        binder:
-#          configuration:
-#            security.protocol: SASL_SSL
-#            sasl.mechanism: PLAIN
+        tkmWalletEventConsumer-in-0:
+          destination: ${topics.tkm-write-update.topic}
+          group: ${topics.tkm-write-update.group}
+          content-type: application/json
+          binder: kafka-tkm-binder
+          consumer:
+            max-attempts: 1
+            ackEachRecord: true
+            ackMode: 'RECORD'
+
+      kafka:
+        binder:
+          configuration:
+            security.protocol: SASL_SSL
+            sasl.mechanism: PLAIN
 
       binders:
         kafka-enrolled-binder:

--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/TestUtils.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/TestUtils.java
@@ -20,6 +20,10 @@ public final class TestUtils {
     return HashPan.create(randomString(64));
   }
 
+  public static String generateRandomHashPanAsString() {
+    return generateRandomHashPan().getValue();
+  }
+
   public static String randomString(int length) {
     return IntStream.range(0, length)
             .mapToObj(i -> "" + ALPHANUMERIC.charAt(random.nextInt(ALPHANUMERIC.length())))

--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/configs/MongodbIntegrationTestConfiguration.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/configs/MongodbIntegrationTestConfiguration.java
@@ -7,12 +7,15 @@ import de.flapdoodle.embed.mongo.config.Net;
 import de.flapdoodle.embed.mongo.config.Storage;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.process.runtime.Network;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerWalletChanged;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.integration.kafka.inbound.KafkaMessageDrivenChannelAdapter;
 
 import javax.annotation.PostConstruct;
 import java.io.IOException;
@@ -23,6 +26,10 @@ public class MongodbIntegrationTestConfiguration {
 
   private static final String IP = "localhost";
   private static final int PORT = 28017;
+
+  /* Useless beans */
+  @MockBean
+  KafkaMessageDrivenChannelAdapter<String, TokenManagerWalletChanged> input;
 
   @Bean
   public MongodConfig embeddedMongoConfiguration() throws IOException {

--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/persistence/EnrolledPaymentInstrumentRepositoryTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/persistence/EnrolledPaymentInstrumentRepositoryTest.java
@@ -2,6 +2,7 @@ package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.pers
 
 
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.TestUtils;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.configs.MongodbIntegrationTestConfiguration;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.EnrolledPaymentInstrument;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.HashPan;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.SourceApp;
@@ -11,13 +12,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.mongo.MongoProperties;
-import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
-import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.Sort.Direction;
@@ -27,18 +24,18 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 
-import javax.annotation.Resource;
 import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@SpringBootTest
+@SpringBootTest()
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @ActiveProfiles("mongo-integration-test")
 @TestPropertySource(properties = {
         "spring.config.location=classpath:application-test.yml"}, inheritProperties = false)
 @AutoConfigureDataMongo
+@Import(MongodbIntegrationTestConfiguration.class)
 class EnrolledPaymentInstrumentRepositoryTest {
 
   private static final HashPan TEST_HASH_PAN = TestUtils.generateRandomHashPan();

--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/persistence/EnrolledPaymentInstrumentRepositoryTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/persistence/EnrolledPaymentInstrumentRepositoryTest.java
@@ -1,4 +1,4 @@
-package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrustructure.persistence;
+package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.persistence;
 
 
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.TestUtils;

--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/persistence/TkmPaymentInstrumentServiceIntegrationTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/persistence/TkmPaymentInstrumentServiceIntegrationTest.java
@@ -1,4 +1,4 @@
-package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrustructure.persistence;
+package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.persistence;
 
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.TestUtils;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application.TkmPaymentInstrumentService;

--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/persistence/TkmPaymentInstrumentServiceIntegrationTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/persistence/TkmPaymentInstrumentServiceIntegrationTest.java
@@ -4,6 +4,7 @@ import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.TestUtils;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application.TkmPaymentInstrumentService;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application.command.TkmRevokeCommand;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application.command.TkmUpdateCommand;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.configs.MongodbIntegrationTestConfiguration;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.HashPan;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.services.InstrumentRevokeNotificationService;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.persistence.mongo.EnrolledPaymentInstrumentEntity;
@@ -34,7 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ActiveProfiles("mongo-integration-test")
 @TestPropertySource(properties = {
         "spring.config.location=classpath:application-test.yml"}, inheritProperties = false)
-@Import(TkmPaymentInstrumentServiceIntegrationTest.Configuration.class)
+@Import({ MongodbIntegrationTestConfiguration.class, TkmPaymentInstrumentServiceIntegrationTest.Configuration.class })
 @AutoConfigureDataMongo
 public class TkmPaymentInstrumentServiceIntegrationTest {
 

--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/splitter/TokenManagerCardEventPublisherIntegrationTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/splitter/TokenManagerCardEventPublisherIntegrationTest.java
@@ -1,8 +1,10 @@
-package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka;
+package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.splitter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.TestUtils;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.configs.KafkaTestConfiguration;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.CardChangeType;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerCardChanged;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,41 +31,44 @@ import org.springframework.test.context.ActiveProfiles;
 import java.time.Duration;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @ActiveProfiles("test")
 @EmbeddedKafka(
-        topics = {"${test.kafka.topic-revoke}"},
-        partitions = 1,
+        topics = {"${test.kafka.topic-tkm}"},
+        partitions = 2,
         bootstrapServersProperty = "spring.embedded.kafka.brokers"
 )
 @Import({KafkaTestConfiguration.class})
 @EnableAutoConfiguration(exclude = {TestSupportBinderAutoConfiguration.class, EmbeddedMongoAutoConfiguration.class, MongoAutoConfiguration.class, MongoDataAutoConfiguration.class})
 @ExtendWith(MockitoExtension.class)
-class KafkaRevokeNotificationServiceTest {
+class TokenManagerCardEventPublisherIntegrationTest {
 
-  @Value("${test.kafka.topic-revoke}")
+  @Value("${test.kafka.topic-tkm}")
   private String topic;
 
   @Autowired
   private StreamBridge bridge;
-  private KafkaRevokeNotificationService revokeNotificationService;
+  private TokenManagerCardEventPublisher cardEventPublisher;
 
   private Consumer<String, String> consumer;
-  private ObjectMapper mapper;
+  private ObjectMapper objectMapper;
 
   @BeforeEach
-  void setUp(@Autowired EmbeddedKafkaBroker broker) {
+  void setup(@Autowired EmbeddedKafkaBroker broker) {
     final var consumerProperties = KafkaTestUtils.consumerProps("group", "true", broker);
     consumer = new DefaultKafkaConsumerFactory<String, String>(consumerProperties).createConsumer();
     consumer.subscribe(List.of(topic));
-    revokeNotificationService = new KafkaRevokeNotificationService("rtdRevokedPi-out-0", bridge);
-    mapper = new ObjectMapper();
+    cardEventPublisher = new TokenManagerCardEventPublisher("cardChangedProducer-out-0", bridge);
+    objectMapper = new ObjectMapper();
   }
 
   @AfterEach
@@ -72,15 +77,31 @@ class KafkaRevokeNotificationServiceTest {
   }
 
   @Test
-  void whenNotifyRevokedCardThenRevokeNotificationProduced() {
-    final var hashPan = TestUtils.generateRandomHashPan();
-    revokeNotificationService.notifyRevoke("taxCode", hashPan);
+  void whenPublishCardChangedEventThenShouldBeProducedOnDifferentPartitions() {
+    final var events = IntStream.range(0, 10)
+            .mapToObj(i -> TestUtils.prepareRandomTokenManagerEvent(CardChangeType.UPDATE).build());
+
+    events.forEach(it -> cardEventPublisher.sendTokenManagerCardChanged(it));
 
     await().ignoreException(NoSuchElementException.class).atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
       final var records = consumer.poll(Duration.ZERO);
-      assertThat(records)
-              .map(it -> mapper.readValue(it.value(), RevokeNotification.class))
-              .allMatch(notification -> "taxCode".equals(notification.getFiscalCode()) && hashPan.getValue().equals(notification.getHashPan()));
+      assertThat(records).hasSize(10);
+      assertThat(records.partitions()).hasSize(2);
+    });
+  }
+
+  @Test
+  void whenPublishCardChangedEventThenMustHaveSamePayload() {
+    final var events = IntStream.range(0, 10)
+            .mapToObj(i -> TestUtils.prepareRandomTokenManagerEvent(CardChangeType.UPDATE).build())
+            .collect(Collectors.toList());
+
+    events.forEach(it -> cardEventPublisher.sendTokenManagerCardChanged(it));
+
+    await().ignoreException(NoSuchElementException.class).atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+      final var records = consumer.poll(Duration.ZERO);
+      assertThat(records).map(it -> objectMapper.readValue(it.value(), TokenManagerCardChanged.class))
+              .hasSameElementsAs(events);
     });
   }
 }

--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/splitter/TokenManagerWalletEventSplitterIntegrationTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/splitter/TokenManagerWalletEventSplitterIntegrationTest.java
@@ -1,0 +1,136 @@
+package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.splitter;
+
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.configs.KafkaTestConfiguration;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.configurations.KafkaConfiguration;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.configurations.SplitterConfiguration;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.CardChangeType;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerCardChanged;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerWalletChanged;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cloud.stream.test.binder.TestSupportBinderAutoConfiguration;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.integration.handler.GenericHandler;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.List;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@ActiveProfiles("test")
+@EmbeddedKafka(
+        topics = {"${test.kafka.topic-wallet-tkm}"},
+        partitions = 1,
+        bootstrapServersProperty = "spring.embedded.kafka.brokers"
+)
+@TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"}, inheritProperties = false)
+@Import(value = {KafkaTestConfiguration.class, KafkaConfiguration.class, SplitterConfiguration.class})
+@EnableAutoConfiguration(exclude = {TestSupportBinderAutoConfiguration.class, EmbeddedMongoAutoConfiguration.class})
+class TokenManagerWalletEventSplitterIntegrationTest {
+
+  @Value("${test.kafka.topic-wallet-tkm}")
+  private String topic;
+
+  @MockBean
+  private Function<TokenManagerWalletChanged, List<TokenManagerCardChanged>> splitter;
+
+  @MockBean
+  private GenericHandler<TokenManagerCardChanged> cardEventPublisher;
+
+  private KafkaTemplate<String, TokenManagerWalletChanged> kafkaTemplate;
+
+  @BeforeEach
+  void setup(@Autowired EmbeddedKafkaBroker broker) {
+    Mockito.reset(cardEventPublisher, splitter);
+    kafkaTemplate = new KafkaTemplate<>(
+            new DefaultKafkaProducerFactory<>(KafkaTestUtils.producerProps(broker), new StringSerializer(), new JsonSerializer<>())
+    );
+  }
+
+  @AfterEach
+  void teardown() {
+    kafkaTemplate.destroy();
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {OptimisticLockingFailureException.class})
+  void whenFailToPublishSplitEventsThenRetryWholeSplitting(Class<? extends Exception> exception) {
+    Mockito.doThrow(exception)
+            .when(cardEventPublisher)
+            .handle(Mockito.any(), Mockito.any());
+
+    Mockito.doReturn(List.of(
+            new TokenManagerCardChanged("hpan", "taxCode", "par", List.of(), CardChangeType.UPDATE))
+    ).when(splitter).apply(Mockito.any());
+
+    final var walletChanged = new TokenManagerWalletChanged("taxCode", new Date(), List.of(
+            new TokenManagerWalletChanged.CardItem("hpan", "par", CardChangeType.UPDATE, null)
+    ));
+
+    kafkaTemplate.send(topic, walletChanged);
+
+    await().pollDelay(Duration.ofSeconds(10)).atMost(Duration.ofSeconds(15)).untilAsserted(() -> {
+      Mockito.verify(cardEventPublisher, Mockito.atLeast(3)).handle(Mockito.any(), Mockito.any());
+    });
+  }
+
+  @ParameterizedTest
+  @ValueSource(classes = {IllegalArgumentException.class})
+  void whenFailToSplitDueToInvalidPayloadThenNoRetryHappens(Class<? extends Exception> exception) {
+    final var walletChanged = new TokenManagerWalletChanged("taxCode", new Date(), List.of(
+            new TokenManagerWalletChanged.CardItem("hpan", "par", CardChangeType.UPDATE, null)
+    ));
+
+    Mockito.doThrow(exception).when(splitter).apply(Mockito.any());
+    kafkaTemplate.send(topic, walletChanged);
+    await().during(Duration.ofSeconds(5)).untilAsserted(() -> {
+      Mockito.verify(splitter, Mockito.times(1)).apply(Mockito.any());
+    });
+  }
+
+  @Test
+  void whenReceiveWalletChangeEventThenSplitAndPublish() {
+    final ArgumentCaptor<TokenManagerCardChanged> captor = ArgumentCaptor.forClass(TokenManagerCardChanged.class);
+    final var walletChanged = new TokenManagerWalletChanged("taxCode", new Date(), List.of());
+    Mockito.doReturn(List.of(
+            new TokenManagerCardChanged("hpan", "taxCode", "par", List.of(), CardChangeType.UPDATE),
+            new TokenManagerCardChanged("hpan2", "taxCode", "par2", List.of(), CardChangeType.UPDATE))
+    ).when(splitter).apply(Mockito.any());
+
+
+    Mockito.doReturn(null).when(cardEventPublisher).handle(Mockito.any(), Mockito.any());
+    kafkaTemplate.send(topic, walletChanged);
+
+    await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
+      Mockito.verify(cardEventPublisher, Mockito.times(2)).handle(captor.capture(), Mockito.any());
+      assertThat(captor.getAllValues()).hasSize(2);
+    });
+  }
+}

--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/splitter/TokenManagerWalletEventSplitterIntegrationTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/splitter/TokenManagerWalletEventSplitterIntegrationTest.java
@@ -68,7 +68,6 @@ class TokenManagerWalletEventSplitterIntegrationTest {
 
   @BeforeEach
   void setup(@Autowired EmbeddedKafkaBroker broker) {
-    Mockito.reset(cardEventPublisher, splitter);
     kafkaTemplate = new KafkaTemplate<>(
             new DefaultKafkaProducerFactory<>(KafkaTestUtils.producerProps(broker), new StringSerializer(), new JsonSerializer<>())
     );
@@ -77,6 +76,7 @@ class TokenManagerWalletEventSplitterIntegrationTest {
   @AfterEach
   void teardown() {
     kafkaTemplate.destroy();
+    Mockito.reset(cardEventPublisher, splitter);
   }
 
   @ParameterizedTest

--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/splitter/TokenManagerWalletEventSplitterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/splitter/TokenManagerWalletEventSplitterTest.java
@@ -1,0 +1,110 @@
+package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.splitter;
+
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.TestUtils;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.CardChangeType;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.HashTokenChangeType;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerCardChanged;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerWalletChanged;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerWalletChanged.HashTokenItem;
+
+class TokenManagerWalletEventSplitterTest {
+
+  private TokenManagerWalletEventSplitter splitter;
+
+  @BeforeEach
+  void setUp() {
+    splitter = new TokenManagerWalletEventSplitter();
+  }
+
+  @Test
+  void whenWalletContainsMultipleCardThenTaxCodeIsCopiedToSplitEvents() {
+    final var cards = IntStream.of(3).mapToObj(i ->
+            new TokenManagerWalletChanged.CardItem(
+                    TestUtils.generateRandomHashPan().getValue(),
+                    "par",
+                    CardChangeType.UPDATE,
+                    Collections.emptyList()
+            )
+    ).collect(Collectors.toList());
+
+    final var walletEvent = new TokenManagerWalletChanged("taxCode", new Date(), cards);
+    final var cardEvents = splitter.apply(walletEvent);
+
+    assertThat(cardEvents)
+            .isNotEmpty()
+            .allMatch(it -> Objects.equals(it.getTaxCode(), "taxCode"));
+  }
+
+  @Test
+  void whenWalletContainsMultipleCardThenEachCardIsAnEvent() {
+    final var hashTokens = List.of(
+            new HashTokenItem(TestUtils.generateRandomHashPanAsString(), HashTokenChangeType.UPDATE),
+            new HashTokenItem(TestUtils.generateRandomHashPanAsString(), HashTokenChangeType.UPDATE),
+            new HashTokenItem(TestUtils.generateRandomHashPanAsString(), HashTokenChangeType.DELETE)
+    );
+    final var cards = IntStream.of(3).mapToObj(i ->
+            new TokenManagerWalletChanged.CardItem(
+                    TestUtils.generateRandomHashPanAsString(),
+                    "par",
+                    CardChangeType.UPDATE,
+                    hashTokens
+            )
+    ).collect(Collectors.toList());
+
+    final var walletEvent = new TokenManagerWalletChanged("taxCode", new Date(), cards);
+    final var cardEvents = splitter.apply(walletEvent);
+
+    // assert over hash tokens
+    assertThat(cardEvents)
+            .flatMap(TokenManagerCardChanged::getHashTokens)
+            .isNotEmpty()
+            .allMatch(it -> hashTokens.stream().anyMatch(that ->
+                    it.getHashToken().equals(that.getHtoken()) && it.getChangeType() == that.getHaction()
+            ));
+
+    assertThat(cardEvents)
+            .isNotEmpty()
+            .allMatch(it -> cards.stream().anyMatch(that ->
+                    that.getHpan().equals(it.getHashPan()) && that.getPar().equals(it.getPar()) &&
+                            that.getAction() == it.getChangeType()
+            ));
+  }
+
+  @Test
+  void whenWalletCardsHaveNullTokensThenCardEventHaveNoTokens() {
+    final var events = splitter.apply(
+            new TokenManagerWalletChanged("taxCode", new Date(),
+                    List.of(
+                            new TokenManagerWalletChanged.CardItem(
+                                    "hpan",
+                                    "par",
+                                    CardChangeType.REVOKE,
+                                    null
+                            )
+                    )
+            )
+    );
+
+    assertThat(events).isNotEmpty().allMatch(it -> it.getHashTokens().isEmpty());
+  }
+
+  @Test
+  void whenWalletHasNullCardThenSplitIntoEmptyList() {
+    final var cardEvents = splitter.apply(
+            new TokenManagerWalletChanged("taxCode", new Date(), null)
+    );
+    assertThat(cardEvents).isEmpty();
+  }
+}

--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/ports/event/ApplicationEnrollEventAdapterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/ports/event/ApplicationEnrollEventAdapterTest.java
@@ -1,6 +1,6 @@
 package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event;
 
-import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.KafkaConfiguration;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.configurations.KafkaConfiguration;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application.EnrolledPaymentInstrumentService;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application.command.EnrollPaymentInstrumentCommand;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application.command.EnrollPaymentInstrumentCommand.Operation;

--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/ports/event/TokenManagerEventAdapterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/ports/event/TokenManagerEventAdapterTest.java
@@ -1,6 +1,6 @@
 package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event;
 
-import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.KafkaConfiguration;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.configurations.KafkaConfiguration;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.TestUtils;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application.TkmPaymentInstrumentService;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application.command.TkmRevokeCommand;

--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/ports/event/routes/PaymentInstrumentEventRouterTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/ports/event/routes/PaymentInstrumentEventRouterTest.java
@@ -4,15 +4,22 @@ package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.routes;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.TestUtils;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.configs.ApplicationTestConfiguration;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.ApplicationEnrollEvent;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.CardChangeType;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerCardChanged;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerWalletChanged;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.integration.kafka.inbound.KafkaMessageDrivenChannelAdapter;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.context.TestPropertySource;
 
@@ -22,8 +29,9 @@ import java.util.UnknownFormatConversionException;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest()
-@EnableAutoConfiguration(exclude = EmbeddedMongoAutoConfiguration.class)
+@EnableAutoConfiguration(exclude = {EmbeddedMongoAutoConfiguration.class, MongoAutoConfiguration.class, MongoDataAutoConfiguration.class})
 @TestPropertySource(properties = {"spring.config.location=classpath:application-test.yml"}, inheritProperties = false)
+@Import(PaymentInstrumentEventRouterTest.Config.class)
 public class PaymentInstrumentEventRouterTest {
 
   private static final String TKM_CONSUMER_DESTINATION = "tkmConsumer";
@@ -88,5 +96,11 @@ public class PaymentInstrumentEventRouterTest {
             UnknownFormatConversionException.class,
             () -> eventRouter.routingResult(MessageBuilder.withPayload(new Object()).build())
     );
+  }
+
+  @Import(ApplicationTestConfiguration.class)
+  public static class Config {
+    @MockBean
+    KafkaMessageDrivenChannelAdapter<String, TokenManagerWalletChanged> input;
   }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -36,6 +36,15 @@ spring:
           consumer:
             max-attempts: 1
 
+        cardChangedProducer-out-0:
+          destination: ${test.kafka.topic-tkm}
+          content-type: application/json
+          binder: kafka-binder
+          producer:
+            partitionKeyExpression: ${KAFKA_PARTITION_KEY_EXPRESSION:headers.partitionKey}
+            partitionCount: ${KAFKA_PARTITION_COUNT:1}
+            sync: true
+
         rtdRevokedPi-out-0:
           destination: ${test.kafka.topic-revoke}
           content-type: application/json

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,7 +4,18 @@ logging:
 
 test.kafka.topic: "embedded-test-topic"
 test.kafka.topic-tkm: "embedded-test-topic-tkm"
+test.kafka.topic-wallet-tkm: "embedded-test-topic-wallet-tkm"
 test.kafka.topic-revoke: "revoke-topic"
+
+integration-flow:
+  tkmBulkConsumer:
+    topic: ${test.kafka.topic-wallet-tkm}
+    bootstrap.servers: ${spring.embedded.kafka.brokers}
+    group.id: "group"
+    key.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    value.deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    allow.auto.create.topics: false
+    max.poll.records: 1
 
 spring:
   config:
@@ -13,7 +24,7 @@ spring:
 
   cloud:
     function:
-      definition: functionRouter;tkmWalletEventConsumer
+      definition: functionRouter
     stream:
       function.routing.enabled: true
       bindings:
@@ -24,12 +35,6 @@ spring:
           binder: kafka-binder
           consumer:
             max-attempts: 1
-
-        tkmWalletEventConsumer-in-0:
-          destination: ${test.kafka.topic-tkm}
-          group: rtd-pim-consumer-group
-          content-type: application/json
-          binder: kafka-binder
 
         rtdRevokedPi-out-0:
           destination: ${test.kafka.topic-revoke}


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR adds a splitter component to split tkm bulk events, which contains multiple cards (wallet), into single card event change. The implementation is supported by spring integration (`IntegrationFlow`).

#### List of Changes
<!--- Describe your changes in detail -->
- custom yaml properties to define kafka integration flow consumer properties. This approach allow to setup a stateful kafka retry when a retryable exceptions is thrown.
- splitter integration flow backed by Spring EIP 
- splitting business logic
- an CardChangedEvent publisher to publish splitted events
- unit test
- narrow integration between splitter logic and integration flow
- narrow integration between integration flow and splitted events

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [x] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.