### PR TITLE
feat: [RTD-776] Ack enroll business logic

### DIFF
--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/application/EnrolledPaymentInstrumentService.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/application/EnrolledPaymentInstrumentService.java
@@ -2,15 +2,19 @@ package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application;
 
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application.command.EnrollPaymentInstrumentCommand;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application.command.EnrollPaymentInstrumentCommand.Operation;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application.errors.EnrollAckError;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.EnrolledPaymentInstrument;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.HashPan;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.PaymentInstrumentEnrolled;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.SourceApp;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.repositories.EnrolledPaymentInstrumentRepository;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.services.EnrollAckService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
 
 import javax.validation.Valid;
+import java.util.Date;
 
 @Service
 @Slf4j
@@ -18,9 +22,11 @@ import javax.validation.Valid;
 public class EnrolledPaymentInstrumentService {
 
   private final EnrolledPaymentInstrumentRepository repository;
+  private final EnrollAckService enrollAckService;
 
-  public EnrolledPaymentInstrumentService(EnrolledPaymentInstrumentRepository repository) {
+  public EnrolledPaymentInstrumentService(EnrolledPaymentInstrumentRepository repository, EnrollAckService enrollAckService) {
     this.repository = repository;
+    this.enrollAckService = enrollAckService;
   }
 
   public void handle(@Valid EnrollPaymentInstrumentCommand command) {
@@ -39,7 +45,24 @@ public class EnrolledPaymentInstrumentService {
     if (paymentInstrument.shouldBeDeleted()) {
       repository.delete(paymentInstrument);
     } else {
+      handleDomainEvents(paymentInstrument);
       repository.save(paymentInstrument);
     }
+  }
+
+  private void handlePaymentInstrumentEnrolled(PaymentInstrumentEnrolled event) {
+    if (enrollAckService.confirmEnroll(event.getApplication(), event.getHashPan(), new Date())) {
+      log.info("Enroll ack successfully confirmed");
+    } else {
+      throw new EnrollAckError("Failing during ack " + event.getHashPan().getValue() + " from " + event.getApplication());
+    }
+  }
+
+  private void handleDomainEvents(EnrolledPaymentInstrument paymentInstrument) {
+    paymentInstrument.domainEvents().forEach(event -> {
+      if (event instanceof PaymentInstrumentEnrolled)
+        handlePaymentInstrumentEnrolled((PaymentInstrumentEnrolled) event);
+    });
+    paymentInstrument.clearDomainEvents();
   }
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/application/errors/EnrollAckError.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/application/errors/EnrollAckError.java
@@ -1,0 +1,7 @@
+package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application.errors;
+
+public class EnrollAckError extends RuntimeException {
+  public EnrollAckError(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/common/AggregateRoot.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/common/AggregateRoot.java
@@ -1,0 +1,41 @@
+package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.common;
+
+
+import org.springframework.data.annotation.Transient;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Abstraction over most important concept of DDD. Also allow to use Domain Events to de-coupling business logic
+ * with application logic (like publishing events).
+ * An aggregate root must allow to achieve a transactional boundary execution, where a specific domain logic
+ * update data in a consistent way.
+ */
+public abstract class AggregateRoot {
+
+  @Transient
+  private final List<DomainEvent> domainEvents;
+
+  protected AggregateRoot() {
+    this(new ArrayList<>());
+  }
+
+  protected AggregateRoot(List<DomainEvent> domainEvents) {
+    this.domainEvents = domainEvents;
+  }
+
+  protected void registerEvent(DomainEvent event) {
+    domainEvents.add(event);
+  }
+
+  public List<DomainEvent> domainEvents() {
+    return Collections.unmodifiableList(domainEvents);
+  }
+
+  public void clearDomainEvents() {
+    domainEvents.clear();
+  }
+
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/common/DomainEvent.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/common/DomainEvent.java
@@ -1,0 +1,4 @@
+package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.common;
+
+public interface DomainEvent {
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/configurations/AppConfiguration.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/configurations/AppConfiguration.java
@@ -4,9 +4,11 @@ import com.mongodb.MongoException;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application.errors.FailedToNotifyRevoke;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.repositories.EnrolledPaymentInstrumentRepository;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.services.ChainRevokeNotificationService;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.services.EnrollAckService;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.services.InstrumentRevokeNotificationService;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.services.VirtualEnrollService;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.BPDRevokeNotificationService;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.ack.KafkaEnrollAckService;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.revoke.KafkaRevokeNotificationService;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.virtualenroll.KafkaVirtualEnrollService;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.persistence.repositories.EnrolledPaymentInstrumentDao;
@@ -45,6 +47,11 @@ public class AppConfiguration {
           EnrolledPaymentInstrumentDao dao
   ) {
     return new EnrolledPaymentInstrumentRepositoryImpl(dao);
+  }
+
+  @Bean
+  public EnrollAckService enrollAckService(StreamBridge bridge) {
+    return new KafkaEnrollAckService(bridge, RTD_TO_APP_BINDING);
   }
 
   @Bean

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/domain/entities/EnrolledPaymentInstrument.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/domain/entities/EnrolledPaymentInstrument.java
@@ -66,7 +66,7 @@ public class EnrolledPaymentInstrument extends AggregateRoot {
    */
   public void enableApp(SourceApp sourceApp) {
     this.state = state == PaymentInstrumentState.REVOKED ? this.state : PaymentInstrumentState.READY;
-    if (this.state == PaymentInstrumentState.READY && !this.enabledApps.contains(sourceApp)) {
+    if (this.state == PaymentInstrumentState.READY) {
       this.enabledApps.add(sourceApp);
       this.registerEvent(new PaymentInstrumentEnrolled(hashPan, sourceApp));
     }

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/domain/entities/PaymentInstrumentEnrolled.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/domain/entities/PaymentInstrumentEnrolled.java
@@ -1,0 +1,14 @@
+package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities;
+
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.common.DomainEvent;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+@Getter
+public class PaymentInstrumentEnrolled implements DomainEvent {
+
+  private final HashPan hashPan;
+  private final SourceApp application;
+
+}

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/domain/services/EnrollAckService.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/domain/services/EnrollAckService.java
@@ -1,9 +1,10 @@
 package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.services;
 
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.HashPan;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.SourceApp;
 
 import java.util.Date;
 
 public interface EnrollAckService {
-  boolean confirmEnroll(HashPan hashPan, Date enrollDate);
+  boolean confirmEnroll(SourceApp app, HashPan hashPan, Date enrollDate);
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/ack/EnrollAck.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/ack/EnrollAck.java
@@ -1,6 +1,7 @@
 package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.ack;
 
 import com.fasterxml.jackson.annotation.JsonAlias;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.SourceApp;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
@@ -21,4 +22,7 @@ public final class EnrollAck {
 
   @JsonAlias("timestamp")
   private Date timestamp;
+
+  @JsonAlias("application")
+  private SourceApp application;
 }

--- a/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/ack/KafkaEnrollAckService.java
+++ b/src/main/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/ack/KafkaEnrollAckService.java
@@ -2,6 +2,7 @@ package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.infrastructure.kafka.ack;
 
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.common.CloudEvent;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.HashPan;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.SourceApp;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.services.EnrollAckService;
 import org.springframework.cloud.stream.function.StreamBridge;
 
@@ -18,8 +19,8 @@ public class KafkaEnrollAckService implements EnrollAckService {
   }
 
   @Override
-  public boolean confirmEnroll(HashPan hashPan, Date enrollDate) {
-    final var payload = new EnrollAck(hashPan.getValue(), enrollDate);
+  public boolean confirmEnroll(SourceApp app, HashPan hashPan, Date enrollDate) {
+    final var payload = new EnrollAck(hashPan.getValue(), enrollDate, app);
     return streamBridge.send(binding, CloudEvent.<EnrollAck>builder()
             .withType(EnrollAck.TYPE)
             .withData(payload)

--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/application/EnrolledPaymentInstrumentServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/application/EnrolledPaymentInstrumentServiceTest.java
@@ -3,10 +3,13 @@ package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.TestUtils;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application.command.EnrollPaymentInstrumentCommand;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application.command.EnrollPaymentInstrumentCommand.Operation;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.application.errors.EnrollAckError;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.EnrolledPaymentInstrument;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.HashPan;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.SourceApp;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.repositories.EnrolledPaymentInstrumentRepository;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.services.EnrollAckService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,15 +27,14 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import javax.validation.ConstraintViolationException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @RunWith(SpringRunner.class)
 @ExtendWith(SpringExtension.class)
@@ -45,16 +47,24 @@ class EnrolledPaymentInstrumentServiceTest {
   private EnrolledPaymentInstrumentRepository repository;
 
   @Autowired
+  private EnrollAckService enrollAckService;
+
+  @Autowired
   private EnrolledPaymentInstrumentService service;
 
   @BeforeEach
   void setup() {
-    Mockito.reset(repository);
+    doReturn(true).when(enrollAckService).confirmEnroll(any(), any(), any());
+  }
+
+  @AfterEach
+  void cleanUp() {
+    Mockito.reset(repository, enrollAckService);
   }
 
   @DisplayName("must enable payment instrument for a specific source app")
   @Test
-  void mustEnablePaymentInstrumentForSpecificApp() {
+  void whenCommandEnablePaymentInstrumentThenEnableForSpecifiedApp() {
     final var argument = ArgumentCaptor.forClass(EnrolledPaymentInstrument.class);
     final var command = new EnrollPaymentInstrumentCommand(
         TEST_HASH_PAN.getValue(),
@@ -90,6 +100,50 @@ class EnrolledPaymentInstrumentServiceTest {
     assertEquals(Collections.singleton(SourceApp.ID_PAY), argument.getValue().getEnabledApps());
   }
 
+  @Test
+  void whenCommandEnableAppThenSendAck() {
+    final var command = new EnrollPaymentInstrumentCommand(
+            TEST_HASH_PAN.getValue(),
+            SourceApp.FA.name(),
+            Operation.CREATE,
+            null,
+            null
+    );
+    service.handle(command);
+
+    verify(enrollAckService).confirmEnroll(eq(SourceApp.FA), eq(TEST_HASH_PAN), any());
+  }
+
+  @Test
+  void whenCommandEnableExistingAppThenSendAck() {
+    final var fullEnrolledInstrument = EnrolledPaymentInstrument.create(TEST_HASH_PAN, Set.of(SourceApp.values()), null, null);
+    fullEnrolledInstrument.clearDomainEvents();
+    when(repository.findByHashPan(any())).thenReturn(Optional.of(fullEnrolledInstrument));
+
+    final var command = new EnrollPaymentInstrumentCommand(
+            TEST_HASH_PAN.getValue(),
+            SourceApp.FA.name(),
+            Operation.CREATE,
+            null,
+            null
+    );
+    service.handle(command);
+    verify(enrollAckService).confirmEnroll(eq(SourceApp.FA), eq(TEST_HASH_PAN), any());
+  }
+
+  @Test
+  void whenSendAckFailThenThrowsException() {
+    final var command = new EnrollPaymentInstrumentCommand(
+            TEST_HASH_PAN.getValue(),
+            SourceApp.FA.name(),
+            Operation.CREATE,
+            null,
+            null
+    );
+    doReturn(false).when(enrollAckService).confirmEnroll(any(), any(), any());
+    assertThrowsExactly(EnrollAckError.class, () -> service.handle(command));
+  }
+
   @DisplayName("must disable payment instrument for a specific source app")
   @Test
   void mustDisablePaymentInstrumentForSpecificApp() {
@@ -103,7 +157,7 @@ class EnrolledPaymentInstrumentServiceTest {
         null
     );
 
-    Mockito.when(repository.findByHashPan(Mockito.any())).thenReturn(Optional.of(fullEnrolledInstrument));
+    when(repository.findByHashPan(any())).thenReturn(Optional.of(fullEnrolledInstrument));
 
     service.handle(command);
     Mockito.verify(repository).save(argument.capture());
@@ -125,11 +179,11 @@ class EnrolledPaymentInstrumentServiceTest {
         null
     ));
 
-    Mockito.when(repository.findByHashPan(Mockito.any())).thenReturn(Optional.of(fullEnrolledInstrument));
+    when(repository.findByHashPan(any())).thenReturn(Optional.of(fullEnrolledInstrument));
 
     commands.forEach(command -> service.handle(command));
 
-    Mockito.verify(repository, Mockito.times(1)).delete(Mockito.any());
+    Mockito.verify(repository, Mockito.times(1)).delete(any());
   }
 
   @DisplayName("must throw exception when command is invalid")
@@ -160,9 +214,12 @@ class EnrolledPaymentInstrumentServiceTest {
     @MockBean
     private EnrolledPaymentInstrumentRepository repository;
 
+    @MockBean
+    private EnrollAckService enrollAckService;
+
     @Bean
     EnrolledPaymentInstrumentService service() {
-      return new EnrolledPaymentInstrumentService(repository);
+      return new EnrolledPaymentInstrumentService(repository, enrollAckService);
     }
   }
 

--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/domain/PaymentInstrumentTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/domain/PaymentInstrumentTest.java
@@ -2,6 +2,7 @@ package it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain;
 
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.TestUtils;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.EnrolledPaymentInstrument;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.PaymentInstrumentEnrolled;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.SourceApp;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -13,18 +14,14 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 class PaymentInstrumentTest {
 
   @Test
   void whenPaymentInstrumentIsCreateWithoutAppsThenMustBeNotEnrolled() {
-    final var paymentInstrument = EnrolledPaymentInstrument.createUnEnrolledInstrument(
-            TestUtils.generateRandomHashPan(),
-            "",
-            ""
-    );
-
+    final var paymentInstrument = EnrolledPaymentInstrument.createUnEnrolledInstrument(TestUtils.generateRandomHashPan());
     assertTrue(paymentInstrument.isNotEnrolled());
     assertFalse(paymentInstrument.isReady());
   }
@@ -43,14 +40,25 @@ class PaymentInstrumentTest {
 
   @Test
   void whenEnabledAppIsAddedThenPaymentInstrumentIsReady() {
-    final var paymentInstrument = EnrolledPaymentInstrument.createUnEnrolledInstrument(
-            TestUtils.generateRandomHashPan(),
-            "",
-            ""
-    );
+    final var paymentInstrument = EnrolledPaymentInstrument.createUnEnrolledInstrument(TestUtils.generateRandomHashPan());
     paymentInstrument.enableApp(SourceApp.FA);
-
     assertTrue(paymentInstrument.isReady());
+  }
+
+  @Test
+  void whenEnrollNewAppThenFirePaymentInstrumentEnrolledEvent() {
+    final var paymentInstrument = EnrolledPaymentInstrument.createUnEnrolledInstrument(TestUtils.generateRandomHashPan());
+    paymentInstrument.enableApp(SourceApp.ID_PAY);
+    assertThat(paymentInstrument.domainEvents())
+            .contains(new PaymentInstrumentEnrolled(paymentInstrument.getHashPan(), SourceApp.ID_PAY));
+  }
+
+  @Test
+  void whenEnrollAnExistingAppThenNoFirePaymentInstrumentEnrolledEvent() {
+    final var paymentInstrument = EnrolledPaymentInstrument.create(TestUtils.generateRandomHashPan(), Set.of(SourceApp.ID_PAY), "", "");
+    paymentInstrument.clearDomainEvents();
+    paymentInstrument.enableApp(SourceApp.ID_PAY);
+    assertThat(paymentInstrument.domainEvents()).isEmpty();
   }
 
   @Test
@@ -95,7 +103,7 @@ class PaymentInstrumentTest {
 
 
   @Test
-  void whenUnenrollAllAppsFromRevokeCardThenShouldBeDeleted() {
+  void whenUnEnrollAllAppsFromRevokeCardThenShouldBeDeleted() {
     final var paymentInstrument = EnrolledPaymentInstrument.create(
             TestUtils.generateRandomHashPan(),
             Set.of(SourceApp.FA, SourceApp.ID_PAY),

--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/domain/PaymentInstrumentTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/domain/PaymentInstrumentTest.java
@@ -54,9 +54,9 @@ class PaymentInstrumentTest {
   }
 
   @Test
-  void whenEnrollAnExistingAppThenNoFirePaymentInstrumentEnrolledEvent() {
-    final var paymentInstrument = EnrolledPaymentInstrument.create(TestUtils.generateRandomHashPan(), Set.of(SourceApp.ID_PAY), "", "");
-    paymentInstrument.clearDomainEvents();
+  void whenEnrollOverRevokedInstrumentThenNoFirePaymentInstrumentEnrolledEvent() {
+    final var paymentInstrument = EnrolledPaymentInstrument.createUnEnrolledInstrument(TestUtils.generateRandomHashPan());
+    paymentInstrument.revokeInstrument();
     paymentInstrument.enableApp(SourceApp.ID_PAY);
     assertThat(paymentInstrument.domainEvents()).isEmpty();
   }

--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/ack/KafkaEnrollAckServiceTest.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/infrastructure/kafka/ack/KafkaEnrollAckServiceTest.java
@@ -6,6 +6,7 @@ import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.TestKafkaConsumerSetup;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.TestUtils;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.common.CloudEvent;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.configs.KafkaTestConfiguration;
+import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.domain.entities.SourceApp;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,7 +76,7 @@ class KafkaEnrollAckServiceTest {
     final var hashPan = TestUtils.generateRandomHashPan();
     final var ackTimestamp = new Date();
     final var type = new TypeReference<CloudEvent<EnrollAck>>() {};
-    kafkaEnrollAckService.confirmEnroll(hashPan, ackTimestamp);
+    kafkaEnrollAckService.confirmEnroll(SourceApp.ID_PAY, hashPan, ackTimestamp);
 
     await().atMost(Duration.ofSeconds(10)).untilAsserted(() -> {
       final var record = testConsumer.getRecords().poll(100, TimeUnit.MILLISECONDS);
@@ -84,7 +85,8 @@ class KafkaEnrollAckServiceTest {
               .extracting(TestUtils.parseTo(mapper, type))
               .matches(it -> it.getType().equals(EnrollAck.TYPE))
               .matches(it -> Objects.equals(it.getData().getHashPan(), hashPan.getValue()))
-              .matches(it -> Objects.equals(it.getData().getTimestamp(), ackTimestamp));
+              .matches(it -> Objects.equals(it.getData().getTimestamp(), ackTimestamp))
+              .matches(it -> Objects.equals(it.getData().getApplication(), SourceApp.ID_PAY));
     });
   }
 }


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR adds ack enroll business logic. Its based over DDD domain events, where the domain execute the enrollment logic and fires a `PaymentInstrumentEnrolled` event which represent and ACK to a vertical application. The events are handled directly by the application service which publish and ACK using an infrastructure service.

This domain events implementation is a naive implementation where the application service handle the domain events. In a better implementation is the repository after saving an aggregate root to fires the events and specific application service handle it.

#### List of Changes
<!--- Describe your changes in detail -->
- added AggregateRoot DDD concept
- added Domain Event DDD concept
- ack event publishing
- unit test & narrow test

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [x] Unit Test Suite
- [x] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.