### PR TITLE
fix: [RTD-1585] Kafka producer must be partitioned

### DIFF
--- a/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/TestUtils.java
+++ b/src/test/java/it/gov/pagopa/rtd/ms/enrolledpaymentinstrument/TestUtils.java
@@ -9,6 +9,7 @@ import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.CardChange
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.HashTokenChangeType;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.PaymentInstrumentExported;
 import it.gov.pagopa.rtd.ms.enrolledpaymentinstrument.ports.event.dto.TokenManagerCardChanged;
+import java.util.stream.Stream;
 import org.springframework.messaging.Message;
 
 import java.util.List;
@@ -73,6 +74,19 @@ public final class TestUtils {
             ).collect(Collectors.toList());
   }
 
+  /**
+   * Return a list of fixed hashpan which guarantee kakfa partitions
+   * are equally distribution over 3 partitions.
+   */
+  public static Stream<String> partitionedHashPans() {
+    return Stream.of(
+        "4tX28JnnyCPmjFSjueDsPHUPwJIEo3Sc0rGSNPQz7fZINB08Fc6S0Q1LxChSCkZL",
+        "97VpsIPFFlEqQtf7etwoz4agNUUM5eMzcBc3uo7mA2kxooGloFeHQdEQ8bb7D0c3",
+        "d7aOTEgQbEitJ7vC7qSlbUIaRx1UD74BoPWwxHXMnwHXCaxUFEOV7ZPOy9Gikb1j",
+        "dCuE8niQFo7mgqMMfEAK7s2mRUndIztOT2isiTqYMoL9h0NPfMO9L3JtUjiKTMt8",
+        "DDcLbQwjbd6FwqjT4ZOlb9Ps3W9GKLlF7eQaQOhJB5kmkTjnzv0qaRQNm1kmSGcn"
+    );
+  }
 
   public static <R> Function<Message<String>, R> parseTo(ObjectMapper mapper, Class<R> clazz) {
     return it -> {


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR fix a kafka producer partitioned test by setting a fixed set of hashpan which guarantee at least one message for partitions

#### List of Changes
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.